### PR TITLE
Protection de l'URI si instance non publique

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -91,7 +91,7 @@ sudo sed -i "/#pluxml_hosts/d" /etc/hosts
 
 # If app is private, remove url to SSOWat conf from skipped_uris
 if [ "$is_public" == "No" ]; then
-  ynh_app_setting_set "$app" unprotected_uris -d
+  ynh_app_setting_set "$app" unprotected_uris "${path}"
 fi
 
 # Add admin to the allowed users


### PR DESCRIPTION
Lors de l'installation du paquet, en paramétrant l'instance pour qu'elle ne soit pas publique, j'ai rencontré une erreur de syntaxe au niveau de la ligne 94 du script "install" (quelque chose comme argument manquant). Mon souhait étant que l'instance pluxml soit inaccessible publiquement depuis Internet, j'ai modifié le script et procédé à des tests concluants. Je vous soumets cette proposition de correctif pour avis.
Ce sont mes premiers pas avec l'intégration d'applications dans YunoHost, tout comme avec Git et Github d'ailleurs, et j'espère ne pas avoir trop dérogé aux règles en vigueur.
