### PR TITLE
Upgrade Pluxml to v5.8.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 ## Overview
 [PluXml](https://www.pluxml.org/) : Blog or CMS storing data in XML.
 
-**Shipped version:** 5.7
+**Shipped version:** 5.8.3
 
 ## Screenshots
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -11,7 +11,7 @@ Si vous n'avez pas YunoHost, consultez [le guide](https://yunohost.org/#/install
 ## Vue d'ensemble
 [PluXml](https://www.pluxml.org/) : Blog ou CMS à l'Xml.
 
-**Version incluse:** 5.7
+**Version incluse:** 5.8.3
 
 ## Captures d'écran
 

--- a/check_process
+++ b/check_process
@@ -19,8 +19,8 @@
 		setup_private=1
 		setup_public=1
 		upgrade=1
-		# 5.7
-		upgrade=1	from_commit=0595d7bb0ffc224508c52ec5952125d77c4200e8
+		# 5.7~ynh1
+		upgrade=1	from_commit=f618522e430dfcb63e1a5843535cf0da165025f3
 		backup_restore=1
 		multi_instance=1
 		# This test is no longer necessary since the version 2.7 (PR: https://github.com/YunoHost/yunohost/pull/304), you can still do it if your app could be installed with this version.
@@ -34,6 +34,6 @@
 Email=
 Notification=none
 ;;; Upgrade options
-	; commit=0595d7bb0ffc224508c52ec5952125d77c4200e8
-		name=5.7
+	; commit=f618522e430dfcb63e1a5843535cf0da165025f3
+		name=5.7~ynh1
 

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/pluxml/PluXml/archive/v5.7.zip
-SOURCE_SUM=e13cf839d01a0c611c83943dce6deb3e0cad5ef81996830994aed6f29f52d7c1
+SOURCE_URL=https://github.com/pluxml/PluXml/archive/v5.8.3.zip
+SOURCE_SUM=ed14b037b69144e4f300788fd46520552cb95d3aea450df57da7994b2461d62d
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=zip
 SOURCE_IN_SUBDIR=true

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Blog or CMS storing data in XML.",
         "fr": "Blog ou CMS à l'Xml."
     },
-    "version": "5.7~ynh1",
+    "version": "5.8.3~ynh1",
     "url": "https://www.pluxml.org/",
     "license": "GPL-2.0-only",
     "maintainer": {

--- a/scripts/install
+++ b/scripts/install
@@ -94,7 +94,7 @@ ynh_add_fpm_config
 #=================================================
 # SETUP APPLICATION WITH CURL
 #=================================================
-ynh_script_progression --message="Setuping application with CURL..."
+ynh_script_progression --message="Setting up application with CURL..."
 
 # Set right permissions for curl install
 chown -R $app: $final_path

--- a/scripts/install
+++ b/scripts/install
@@ -110,7 +110,7 @@ ynh_systemd_action --service_name=nginx --action=reload
 
 # Installation with curl
 ynh_script_progression --message="Finalizing installation..."
-ynh_local_curl "/install.php" "default_lang=$language" "install=Installer" "name=$admin" "login=$admin" "pwd=$password" "pwd2=$password" 
+ynh_local_curl "/install.php" "default_lang=$language" "install=Installer" "name=$admin" "login=$admin" "pwd=$password" "pwd2=$password" "data=1" "email=$admin@$domain" "timezone=Europe/Paris"
 
 # Remove the public access
 if [ $is_public -eq 0 ]

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -116,7 +116,8 @@ ynh_add_fpm_config
 #=================================================
 ynh_script_progression --message="Setting up application with CURL..."
 
-ynh_local_curl "/update/index.php" "submit=Démarrer la mise à jour"
+chown -R "$app":"$app" $final_path
+ynh_local_curl "/update/index.php" "submit=submit"
 
 #=================================================
 # REMOVING NO MORE NEEDED FILES

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -112,6 +112,13 @@ ynh_add_fpm_config
 #=================================================
 # SPECIFIC UPGRADE
 #=================================================
+# SETUP APPLICATION WITH CURL
+#=================================================
+ynh_script_progression --message="Setting up application with CURL..."
+
+ynh_local_curl "/update/index.php" "submit=Démarrer la mise à jour"
+
+#=================================================
 # REMOVING NO MORE NEEDED FILES
 #=================================================
 ynh_script_progression --message="Removing install.php and /update"


### PR DESCRIPTION
## Problem
- Pluxml version is v5.7. Version 5.8.3 is nom available. Fix #42 

## Solution
- Upgrade to v5.8.3

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** :  

- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/pluxml_ynh%20(antoine)/1/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/pluxml_ynh%20(antoine)/1/)
